### PR TITLE
Fix #4: Update base dependency so project is compatible with Stack lt…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cabal-dev
 .hpc
 .hsenv
 .cabal-sandbox/
+.stack-work/
 cabal.sandbox.config
 cabal.config
 *.prof

--- a/doctest-discover.cabal
+++ b/doctest-discover.cabal
@@ -13,12 +13,12 @@ cabal-version:       >=1.10
 
 library
   default-language:    Haskell2010
-  build-depends:       base >=4.6 && <4.8, doctest, directory, filepath, aeson, bytestring
+  build-depends:       base >= 4.7 && < 5, doctest, directory, filepath, aeson, bytestring
   HS-Source-Dirs:      src
 
 executable doctest-discover
   default-language:    Haskell2010
-  build-depends:       base >=4.6 && <4.8, doctest, directory, filepath, aeson, bytestring
+  build-depends:       base >= 4.7 && < 5, doctest, directory, filepath, aeson, bytestring
   main-is:             Main.hs 
   other-modules:       Runner, Config
   HS-Source-Dirs:      src
@@ -28,5 +28,5 @@ test-suite doctests
   type:                exitcode-stdio-1.0
   ghc-options:         -threaded
   main-is:             Doctest-Main.hs
-  build-depends:       base >4 && <5, doctest-discover, doctest
+  build-depends:       base >= 4.7 && < 5, doctest-discover, doctest
   HS-Source-Dirs:      test

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,32 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.20
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
Addresses issue #4. Also adds `stack.yaml` configuration file and ignores `.stack-work` Stack working directory.

Project builds and tests successfully with this change using:

    $ stack build
    doctest-discover-0.1.0.6: configure
    Configuring doctest-discover-0.1.0.6...
    doctest-discover-0.1.0.6: build
    Preprocessing library doctest-discover-0.1.0.6...
    In-place registering doctest-discover-0.1.0.6...
    Preprocessing executable 'doctest-discover' for doctest-discover-0.1.0.6...
    [1 of 3] Compiling Config           ( src/Config.hs, .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/doctest-discover/doctest-discover-tmp/Config.o )
    [2 of 3] Compiling Runner           ( src/Runner.hs, .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/doctest-discover/doctest-discover-tmp/Runner.o )
    [3 of 3] Compiling Main             ( src/Main.hs, .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/doctest-discover/doctest-discover-tmp/Main.o )
    Linking .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/doctest-discover/doctest-discover ...
    doctest-discover-0.1.0.6: copy/register
    Installing library in
    /data/home/rcook/src/doctest-discover/.stack-work/install/x86_64-linux/lts-3.20/7.10.2/lib/x86_64-linux-ghc-7.10.2/doctest-discover-0.1.0.6-01xDW4zlclVKk46EMAh9Om
    Installing executable(s) in
    /data/home/rcook/src/doctest-discover/.stack-work/install/x86_64-linux/lts-3.20/7.10.2/bin
    Registering doctest-discover-0.1.0.6...
    $ stack test
    doctest-discover-0.1.0.6: unregistering (components added: test:doctests)
    doctest-discover-0.1.0.6: build (lib + exe + test)
    Preprocessing library doctest-discover-0.1.0.6...
    In-place registering doctest-discover-0.1.0.6...
    Preprocessing executable 'doctest-discover' for doctest-discover-0.1.0.6...
    Preprocessing test suite 'doctests' for doctest-discover-0.1.0.6...
    [1 of 1] Compiling Main             ( test/Doctest-Main.hs, .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/doctests/doctests-tmp/Main.o )
    Linking .stack-work/dist/x86_64-linux/Cabal-1.22.4.0/build/doctests/doctests ...
    doctest-discover-0.1.0.6: copy/register
    Installing library in
    /data/home/rcook/src/doctest-discover/.stack-work/install/x86_64-linux/lts-3.20/7.10.2/lib/x86_64-linux-ghc-7.10.2/doctest-discover-0.1.0.6-01xDW4zlclVKk46EMAh9Om
    Installing executable(s) in
    /data/home/rcook/src/doctest-discover/.stack-work/install/x86_64-linux/lts-3.20/7.10.2/bin
    Registering doctest-discover-0.1.0.6...
    doctest-discover-0.1.0.6: test (suite: doctests)

    Examples: 18  Tried: 18  Errors: 0  Failures: 0 Failures: 0
    Completed 2 action(s).
