### PR TITLE
Test by Travis-CI failed.

### DIFF
--- a/doctest-discover.cabal
+++ b/doctest-discover.cabal
@@ -32,5 +32,5 @@ test-suite doctests
   type:                exitcode-stdio-1.0
   ghc-options:         -threaded
   main-is:             Doctest-Main.hs
-  build-depends:       base >= 4.7 && < 5, doctest-discover, doctest
+  build-depends:       base >= 4.7 && < 5, doctest
   HS-Source-Dirs:      test

--- a/test/Doctest-Main.hs
+++ b/test/Doctest-Main.hs
@@ -1,1 +1,4 @@
-{-# OPTIONS_GHC -F -pgmF doctest-discover #-}
+import Test.DocTest
+
+main :: IO ()
+main = doctest ["src"]


### PR DESCRIPTION
Hi. Test by Travis-CI failed ([log](https://travis-ci.org/Hexirp/doctest-discover/builds/269602730)). Cabal package probably can't use itself as a pre-processor. I fixed it ([log](https://travis-ci.org/Hexirp/doctest-discover/builds/269809356)).